### PR TITLE
Fix how we compile the custom derivation strategy

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,10 +1,20 @@
+import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy
+
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
 }
 
+sourceSets {
+    create("javaInternal") {
+        java.srcDir("src/main/java-internal")
+    }
+}
+
 dependencies {
-    compile(gradleApi())
+    "javaInternalCompileOnly"(files(File(JavaEcosystemVariantDerivationStrategy::class.java.protectionDomain.codeSource.location.toURI())))
+    "javaInternalCompileOnly"("com.google.guava:guava:26.0-android")
+    compile(sourceSets.getByName("javaInternal").output)
 }
 
 repositories {

--- a/buildSrc/src/main/java-internal/JenkinsEcosystemVariantDerivationStrategy.java
+++ b/buildSrc/src/main/java-internal/JenkinsEcosystemVariantDerivationStrategy.java
@@ -1,13 +1,21 @@
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.impldep.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 
-public class JenkinsEcosystemVariantDerivationStrategy extends JavaEcosystemVariantDerivationStrategy {
+public class JenkinsEcosystemVariantDerivationStrategy implements VariantDerivationStrategy {
+    private final VariantDerivationStrategy delegate = new JavaEcosystemVariantDerivationStrategy();
+
+    @Override
+    public boolean derivesVariants() {
+        return true;
+    }
+
     @Override
     public ImmutableList<? extends ConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata) {
         System.out.println("Resolving Jenkins variants");
-        ImmutableList<? extends ConfigurationMetadata> javaVariants = super.derive(metadata);
+        ImmutableList<? extends ConfigurationMetadata> javaVariants = delegate.derive(metadata);
         if (javaVariants == null) {
             return null;
         }


### PR DESCRIPTION
This works around the fact we're implementing a relocated internal
API.

Don't do this at home.